### PR TITLE
Replace hematite flicker with looping glitch transition

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,11 +94,36 @@ img.over{
 	animation: glitch-slice 6s steps(1, end) infinite;
 }
 
+.image::after{
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 4;
+	pointer-events: none;
+	opacity: 0;
+	mix-blend-mode: screen;
+	background: repeating-linear-gradient(
+		to bottom,
+		transparent 0px,
+		transparent 7px,
+		rgba(200, 80, 60, 0.18) 7px,
+		rgba(200, 80, 60, 0.18) 9px
+	);
+	animation: glitch-band 6s steps(1, end) infinite;
+}
+
 .image:hover img.over{
 	opacity: 0;
 	animation: none;
 }
 .image:hover::before{
+	opacity: 0;
+	animation: none;
+}
+.image:hover::after{
 	opacity: 0;
 	animation: none;
 }
@@ -175,6 +200,41 @@ ul.links > li {
 		transform: translate(0, 0);
 		filter: none;
 	}
+}
+
+/* horizontal bands that shift position during glitch bursts */
+@keyframes glitch-band {
+	0%, 26% { opacity: 0; }
+	27% {
+		opacity: 1;
+		background-position: 0 3px;
+		transform: translateX(5px);
+	}
+	28% { opacity: 0; }
+	29% {
+		opacity: 0.8;
+		background-position: 0 -5px;
+		transform: translateX(-3px);
+	}
+	30% { opacity: 0; }
+	32% {
+		opacity: 0.9;
+		background-position: 0 7px;
+		transform: translateX(2px);
+	}
+	34%, 60% { opacity: 0; }
+	62% {
+		opacity: 1;
+		background-position: 0 -4px;
+		transform: translateX(-5px);
+	}
+	64% { opacity: 0; }
+	66% {
+		opacity: 0.8;
+		background-position: 0 6px;
+		transform: translateX(3px);
+	}
+	68%, 100% { opacity: 0; }
 }
 
 /* torn, color-shifted slices that flash only during the transition bursts */

--- a/css/style.css
+++ b/css/style.css
@@ -51,18 +51,56 @@ div.caption{
 	z-index: 200;
 }
 
+.image{
+	position: relative;
+	display: inline-block;
+	width: 440px;
+	max-width: 90vw;
+	aspect-ratio: 440 / 345;
+	margin: 0 auto;
+}
+
+.image img{
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
 img.under{
 	visibility: visible;
 	z-index: 0;
 }
 img.over{
-	margin-top: -345px;
 	z-index: 2;
-	animation: flicker 5s ease alternate infinite;
+	animation: glitch-crossfade 6s steps(1, end) infinite;
 }
 
-img.over:hover{
+.image::before{
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 3;
+	background-image: url(../media/hematite.png);
+	background-size: cover;
+	mix-blend-mode: screen;
+	pointer-events: none;
 	opacity: 0;
+	animation: glitch-slice 6s steps(1, end) infinite;
+}
+
+.image:hover img.over{
+	opacity: 0;
+	animation: none;
+}
+.image:hover::before{
+	opacity: 0;
+	animation: none;
 }
 
 ul.links > li {
@@ -81,20 +119,107 @@ ul.links > li {
 }
 
 /* animations */
-@keyframes flicker{
-	from {
+
+/* crossfades between the sketch (under) and photo (over) with a jump-cut
+   glitch burst around each transition instead of a smooth fade */
+@keyframes glitch-crossfade{
+	0%, 26% {
+		opacity: 0;
+		transform: translate(0, 0);
+		filter: none;
+	}
+	27% {
 		opacity: 1;
+		transform: translate(-3px, 1px);
+		filter: hue-rotate(15deg);
 	}
-	23% {
-		opacity: 0.50;
+	28% {
+		opacity: 0;
+		transform: translate(2px, -1px);
 	}
-	45% {
-		opacity: 0.15;
+	30% {
+		opacity: 1;
+		transform: translate(4px, 0);
+		filter: hue-rotate(-10deg);
 	}
-	68% {
-		opacity: 0.46;
+	31% {
+		opacity: 0;
 	}
-	to {
+	33% {
+		opacity: 1;
+		transform: translate(-2px, 2px);
+	}
+	35%, 60% {
+		opacity: 1;
+		transform: translate(0, 0);
+		filter: none;
+	}
+	62% {
+		opacity: 0;
+		transform: translate(3px, -2px);
+	}
+	63% {
+		opacity: 1;
+		transform: translate(-4px, 1px);
+		filter: hue-rotate(20deg);
+	}
+	65% {
+		opacity: 0;
+	}
+	67% {
+		opacity: 1;
+		transform: translate(2px, 0);
+	}
+	69%, 100% {
+		opacity: 0;
+		transform: translate(0, 0);
+		filter: none;
+	}
+}
+
+/* torn, color-shifted slices that flash only during the transition bursts */
+@keyframes glitch-slice{
+	0%, 26% {
+		opacity: 0;
+	}
+	27% {
+		opacity: 0.6;
+		clip-path: inset(10% 0 60% 0);
+		transform: translateX(6px);
+	}
+	28% {
+		opacity: 0;
+	}
+	29% {
+		opacity: 0.5;
+		clip-path: inset(55% 0 5% 0);
+		transform: translateX(-6px);
+	}
+	30% {
+		opacity: 0;
+	}
+	32% {
+		opacity: 0.55;
+		clip-path: inset(30% 0 40% 0);
+		transform: translateX(5px);
+	}
+	34%, 60% {
+		opacity: 0;
+	}
+	62% {
+		opacity: 0.5;
+		clip-path: inset(15% 0 55% 0);
+		transform: translateX(-5px);
+	}
+	64% {
+		opacity: 0;
+	}
+	66% {
+		opacity: 0.55;
+		clip-path: inset(45% 0 20% 0);
+		transform: translateX(6px);
+	}
+	68%, 100% {
 		opacity: 0;
 	}
 }

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!--doctype html-->
+<!DOCTYPE html>
 <html>
 	<head>
 		<!-- Global site tag (gtag.js) - Google Analytics -->
@@ -32,7 +32,6 @@
 				</div>
 			</div>
 			<ul class="links">
-				<li><a href=./media/CV.pdf>CV</a></li>
 				<li>
 					<tr><a href=./media/resume.pdf>Resume</a></tr>
 					<tr class="docx"><a href="./media/resume.docx">(docx)</a></tr>

--- a/script/preview.sh
+++ b/script/preview.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+python -m http.server 8080


### PR DESCRIPTION
Swap the negative-margin image stacking hack for absolute-positioned
layers inside a sized .image container (responsive, no magic offsets).
The over image now crossfades into the under image on a timed loop with
a jump-cut glitch burst (steps() timing, hue-rotate jitter, translated
torn slices via a screen-blended ::before layer) instead of a plain
opacity flicker.